### PR TITLE
Sources are no longer available

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -55,6 +55,7 @@ class boundary::dependencies {
       apt::source { 'boundary':
         location   => inline_template('<%= "http://apt#{@repo_mod}.boundary.com/#{@operatingsystem.downcase}" %>'),
         repos      => $repo,
+        include_src => false,
         key        => '6532CC20',
         key_source => "http://apt$repo_mod.boundary.com/APT-GPG-KEY-Boundary"
       }


### PR DESCRIPTION
Therefore, the deb-src line would lead to errors and a failing update of
the apt-sources. This, in turn, leads potentially to mails being sent to 
the admins. Which, finally results in full INBOXes and stressed admins.

I tested this in my own (Ubuntu trusty-)setup. 
